### PR TITLE
Allow untracked configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@ zefiro
 ======
 
 Small Content Management Framework in PHP/MySQL
+
+## Configuration
+
+```
+cp custom/config.default.php custom/config.php
+```
+

--- a/custom/config.default.php
+++ b/custom/config.default.php
@@ -1,6 +1,6 @@
 <?php
 // Zefiro Configuration File
-// last update: 2014-01-27
+// last update: 2018-10-22
 
 // PHP DEBUGGING INFO ==========================================================
 
@@ -75,4 +75,6 @@ define('DBI_LIST_ROWS_MAX',				5000);
 define('DBI_LIST_ROWS_PAGE',			20);
 define('DBI_LIST_ROWS_SKIP',			200); // 0 = disabled
 
-?>
+// SYMBOLS ==========================================================
+define('Z_SEPARATOR_SYMBOL',			'|');
+

--- a/zefiro/ini.php
+++ b/zefiro/ini.php
@@ -13,7 +13,11 @@ session_start();
 // - delete custom/config.php
 // - make a copy of custom/config.default.php
 // - rename this file to custom/config.php
-require_once 'custom/config.php';
+if(file_exists('custom/config.php')) {
+    require_once 'custom/config.php';
+} else {
+    require_once 'custom/config.default.php';
+}
 
 // set default language, if neccessary
 if (!isset ($_SESSION[Z_SESSION_NAME]['language'])) {


### PR DESCRIPTION
Before this patch, custom/config.php is tracked by Git. When custo-
mized, changes will appear in `git status` and certain actions are
not allowed to perform. This configuration should not be tracked
in a public Git repo.

Therefore, rename config.php to config.default.php, load config.php
if it exists, otherwise config.default.php.